### PR TITLE
doc: add initial CODEOWNERS and MAINTAINERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Repo-Level Owners (in alphabetical order)
+# Note: This is only for the notaryproject/notation-hashicorp-vault repo
+* @cipherboy @OliverShang @priteshbandi @shizhMSFT

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Repo-Level Owners (in alphabetical order)
 # Note: This is only for the notaryproject/notation-hashicorp-vault repo
-* @cipherboy @OliverShang @priteshbandi @shizhMSFT
+* @cipherboy @OliverShang @Two-Hearts @shizhMSFT

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,6 @@
+# Repo-Level Maintainers (in alphabetical order)
+# Note: This is for the notaryproject/notation-hashicorp-vault repo
+Alexander Scheel <alex.scheel@hashicorp.com> (@cipherboy)
+Bingqi Shang <bingqi.shang.apply@gmail.com> (@OliverShang)
+Patrick Zheng <patrickzheng@microsoft.com> (@patrickzheng200)
+Shiwei Zhang <shizh@microsoft.com> (@shizhMSFT)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,5 +2,5 @@
 # Note: This is for the notaryproject/notation-hashicorp-vault repo
 Alexander Scheel <alex.scheel@hashicorp.com> (@cipherboy)
 Bingqi Shang <bingqi.shang.apply@gmail.com> (@OliverShang)
-Patrick Zheng <patrickzheng@microsoft.com> (@patrickzheng200)
+Patrick Zheng <patrickzheng@microsoft.com> (@Two-Hearts)
 Shiwei Zhang <shizh@microsoft.com> (@shizhMSFT)


### PR DESCRIPTION
Add initial CODEOWNERS and MAINTAINERS per discussion in https://github.com/notaryproject/.github/issues/26. I hope @notaryproject/notaryproject-governance-maintainers @notaryproject/notaryproject-org-maintainers could help to review and approve this PR. Thanks!