### PR TITLE
Add production ACL policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,43 @@ Note: the `--id` should be identical to your `--key_name` in the previous step.
     ```bash
     ./notation verify <myRegistry>/<myRepo>@<digest> -v
     ```
+
+## Vault ACL Policy
+
+This signing plugin (`notation-hc-vault`) interacts with the following paths:
+
+ - read on `secret/data/:keyid`
+ - update on `transit/sign/:keyid`
+
+Thus the following ACL policy would be required for this plugin:
+
+```hcl
+path "secret/data/:keyid" {
+    capabilities = ["read"]
+}
+
+path "transit/sign/:keyid" {
+    capabilities = ["update"]
+}
+```
+
+This plugin's helper `key-helper` for rotating signed certificates
+interacts with the following paths:
+
+ - create or update on `secret/data/:keyid`
+ - update on `transit/keys/:keyid/import`
+
+Thus the following ACL policy would be required for this helper:
+
+```hcl
+path "secret/data/:keyid" {
+    capabilities = ["create", "update"]
+}
+
+path "transit/keys/:keyid/import" {
+    capabilities = ["update"]
+}
+```
+
+Refer to the Hashicorp Vault [tutorial for policies](https://developer.hashicorp.com/vault/tutorials/policies/policy-templating)
+for more information on using policies.


### PR DESCRIPTION
\o As promised (though, late!), here's the ACL policies I was thinking about. I've linked to our tutorial about configuring an ACL policy for instructions on provisioning it, though note that this depends on the auth method used (for linking token creation to specific policies). 

One comment: Vault 1.15 is right around the corner, and with it comes the mentioned X509 support within Transit. As this plugin isn't yet released, it seems like it might be a good time to drop the dependency on KVv2 and instead rely just on Transit. Happy to provide a PR if desired.

(Also, I was noticing that it seems like the path to Transit or KV aren't configurable -- is there a pattern for providing configuration information to plugins? A lot of customers won't use a fixed transit in the root namespace).