### PR TITLE
[WIP] Add support for longer RSA keys longer than 2048, init ECDSA support

### DIFF
--- a/cmd/key-helper/importKey.go
+++ b/cmd/key-helper/importKey.go
@@ -100,12 +100,13 @@ func getWrappingKey(ctx context.Context, client *vault.Client) (string, error) {
 }
 
 func wrapPrivateKey(wrappingKey string, privateKeyPath string) (string, string, error) {
-	// Key types supported by Notary project specification
+	// Key mapping length to Vault/OpenBao names (supported by Notary project specification)
 	supportedRSAKeys := map[int]string{
 		2048: "rsa-2048",
 		3072: "rsa-3072",
 		4096: "rsa-4096",
 	}
+	// Key mapping curve name to Vault/OpenBao names (supported by Notary project specification)
 	supportedECDSAKeys := map[string]string{
 		"P-256": "ecdsa-p256",
 		"P-384": "ecdsa-p384",

--- a/internal/keyvault/keyvault.go
+++ b/internal/keyvault/keyvault.go
@@ -5,10 +5,11 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
-	vault "github.com/hashicorp/vault/api"
-	"github.com/notaryproject/notation-hashicorp-vault/internal/crypto"
 	"os"
 	"strings"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/notaryproject/notation-hashicorp-vault/internal/crypto"
 )
 
 type VaultClientWrapper struct {
@@ -52,7 +53,7 @@ func (vw *VaultClientWrapper) GetCertificateChain(ctx context.Context) ([]*x509.
 	return crypto.ParseCertificates(certBytes)
 }
 
-func (vw *VaultClientWrapper) SignWithTransit(ctx context.Context, encodedData string, signAlgorithm string) ([]byte, error) {
+func (vw *VaultClientWrapper) SignWithTransit(ctx context.Context, encodedData string, signAlgorithm string, hashAlgorithm string) ([]byte, error) {
 	// sign with transit SE
 	transitSignReq := map[string]interface{}{
 		"input":                encodedData,
@@ -60,6 +61,7 @@ func (vw *VaultClientWrapper) SignWithTransit(ctx context.Context, encodedData s
 		"prehashed":            true,
 		"salt_length":          "hash",
 		"signature_algorithm":  signAlgorithm,
+		"hash_algorithm":       hashAlgorithm,
 	}
 	path := "transit/sign/" + vw.keyID
 	resp, err := vw.vaultClient.Logical().WriteWithContext(ctx, path, transitSignReq)

--- a/internal/signature/signer.go
+++ b/internal/signature/signer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+
 	"github.com/notaryproject/notation-go/plugin/proto"
 	"github.com/notaryproject/notation-hashicorp-vault/internal/keyvault"
 )
@@ -62,6 +63,14 @@ func Sign(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.Gene
 		}
 	}
 
+	// Map of Notation RSA-OAEP hash algorithms to Vault's transit engine /sign endpoint equivalent
+	vaultHashAlgorithms := map[string]string{
+		"SHA-256": "sha2-256",
+		"SHA-384": "sha2-384",
+		"SHA-512": "sha2-512",
+	}
+	vaultHashAlgorithm := vaultHashAlgorithms[string(req.Hash)]
+
 	// compute hash for the payload
 	hashData, err := computeHash(keySpec.SignatureAlgorithm().Hash(), req.Payload)
 	if err != nil {
@@ -71,7 +80,7 @@ func Sign(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.Gene
 		}
 	}
 	encodedHash := base64.StdEncoding.EncodeToString(hashData)
-	sigBytes, err := vaultClient.SignWithTransit(ctx, encodedHash, signAlgorithm)
+	sigBytes, err := vaultClient.SignWithTransit(ctx, encodedHash, signAlgorithm, vaultHashAlgorithm)
 	if err != nil {
 		return nil, &proto.RequestError{
 			Code: proto.ErrorCodeGeneric,

--- a/internal/signature/signer.go
+++ b/internal/signature/signer.go
@@ -63,7 +63,7 @@ func Sign(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.Gene
 		}
 	}
 
-	// Map of Notation RSA-OAEP hash algorithms to Vault's transit engine /sign endpoint equivalent
+	// Notary to OpenBao/Vault hash algorithm naming conversion map
 	vaultHashAlgorithms := map[string]string{
 		"SHA-256": "sha2-256",
 		"SHA-384": "sha2-384",


### PR DESCRIPTION
Closes #20

as @cipherboy suggested I have created the code to support longer RSA and added support for ECDSA keys

Looking forward to suggestions as I'm not very proficient in Go yet :) 

- RSA part was tested (load key, sign) with 4096 bit keys.
- ECDSA was tested with ecdsa-p521 curve (load only yet)