### PR TITLE
Configurable KV/transit engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,28 @@ Note: the `--id` should be identical to your `--key_name` in the previous step.
     ```bash
     ./notation verify <myRegistry>/<myRepo>@<digest> -v
     ```
+
+## hc-vault plugin options (passed as `notation sign (...)` command options
+|Option name    |Usage                                   |Description                                                           |
+|---------------|----------------------------------------|-----------------------------------------------------------------------|
+|id             |`--id <keyName>`                        |(required) default name for transit key and kv key                     |
+|kvName         |`--plugin-config kvName=<name>`         |(default: `secret`) custom name for key-value(KVv2) secret engine mount|
+|transitName    |`--plugin-config transitName=<name>`    |(default: `transit`) custom name for transit secret engine mount       |
+|transitKeyName |`--plugin-config transitKeyName=<name>` |custom name for transit key (overrides `id`)                           |
+
+## key-helper import options
+notation-hashicorp-vault % ./cmd/key-helper/key-helper import --help
+import private key to Vault Transit secrets engine and certificates to Vault KV secrets engine
+
+Usage:
+  key-helper import --key_path <path_to_private key file> --cert_path <path_to__certificate_chain_file> --key_name <HashiCorp_Vault_key_name> [flags]
+
+Flags:
+      --cert_path string          absolute path to the certificate chain file
+  -h, --help                      help for import
+      --key_name string           name of the key
+      --key_path string           absolute path to the private key file
+      --kv_name string            name of the KVv2 secret engine mount (default "secret")
+      --transit_key_name string   name of the key in transit engine
+      --transit_name string       name of the transit engine mount (default "transit")
+notation-hashicorp-vault %

--- a/cmd/notation-hc-vault/key.go
+++ b/cmd/notation-hc-vault/key.go
@@ -23,7 +23,7 @@ func runDescribeKey(ctx context.Context, input io.Reader) (*proto.DescribeKeyRes
 	}
 
 	// get key spec for notation
-	keySpec, err := notationKeySpec(ctx, req.KeyID)
+	keySpec, err := notationKeySpec(ctx, req.KeyID, req.PluginConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -33,8 +33,8 @@ func runDescribeKey(ctx context.Context, input io.Reader) (*proto.DescribeKeyRes
 	}, nil
 }
 
-func notationKeySpec(ctx context.Context, keyID string) (proto.KeySpec, error) {
-	vaultClient, err := NewVaultClientFromKeyID(keyID)
+func notationKeySpec(ctx context.Context, keyID string, pluginConfig map[string]string) (proto.KeySpec, error) {
+	vaultClient, err := NewVaultClientFromKeyID(keyID, pluginConfig)
 	if err != nil {
 		return "", err
 	}

--- a/internal/keyvault/keyvault.go
+++ b/internal/keyvault/keyvault.go
@@ -46,7 +46,7 @@ func NewVaultClientFromKeyID(id string, pluginConfig map[string]string) (*VaultC
 	}
 	transitKeyName, ok := pluginConfig["transitKeyName"]
 	if !ok {
-		transitKeyName = ""
+		transitKeyName = id
 	}
 
 	return &VaultClientWrapper{

--- a/internal/signature/signer.go
+++ b/internal/signature/signer.go
@@ -21,7 +21,7 @@ func Sign(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.Gene
 		}
 	}
 
-	vaultClient, err := keyvault.NewVaultClientFromKeyID(req.KeyID)
+	vaultClient, err := keyvault.NewVaultClientFromKeyID(req.KeyID, req.PluginConfig)
 	if err != nil {
 		return nil, &proto.RequestError{
 			Code: proto.ErrorCodeGeneric,


### PR DESCRIPTION
Hey!

I wrote a little patch for support configurable engines mountpoints and keys in Vault

This code allows to:
- set non-standard mountpoints/names for transit/kv engine
- set different key name for transit key (as it's unable to be nested in transit, while kv allows it)

Naming is inconsistent yet, and not very well-thought, so I'm open for suggestions :)